### PR TITLE
Get new field value for comparision and throwing value change through getter

### DIFF
--- a/src/main/java/CubaEnhancer.java
+++ b/src/main/java/CubaEnhancer.java
@@ -124,14 +124,16 @@ public class CubaEnhancer {
             }
 
             ctMethod.addLocalVariable("__prev", setterParamType);
+            ctMethod.addLocalVariable("__new", setterParamType);
 
             ctMethod.insertBefore(
                     "__prev = this.get" + StringUtils.capitalize(fieldName) + "();"
             );
 
             ctMethod.insertAfter(
-                    "if (!com.haulmont.chile.core.model.utils.InstanceUtils.propertyValueEquals(__prev, $1)) {" +
-                    "  this.propertyChanged(\"" + fieldName + "\", __prev, $1);" +
+                    "__new = this.get" + StringUtils.capitalize(fieldName) + "();" +
+                    "if (!com.haulmont.chile.core.model.utils.InstanceUtils.propertyValueEquals(__prev, __new)) {" +
+                    "  this.propertyChanged(\"" + fieldName + "\", __prev, __new);" +
                     "}"
             );
         }


### PR DESCRIPTION
Suppose we have entity with such property:
```
public class MyEntity extends StandardEntity {
   @Column(name = "my_value")
   BigDecimal myValue;

   public void setMyValue(BigDecimal myValue) {
        this.myValue = myValue;
    }

    public BigDecimal getMyValue() {
        return this.myValue != null ? this.myValue : BigDecimal.ZERO;
    }
}
```

Now we call setter method `myEntity.setMyValue(null) ` in that case enhanced setter will throw wrong value change event with `null` as new value, though there should be an `BigDecimal.ZERO`.

In some cases this will lead to wrong logic in listeners.

This fix is getting new value through getter after internal set value and compares it with previous value and fires property change event with this new value.