### PR TITLE
improve enhancer error message

### DIFF
--- a/src/main/java/com/haulmont/gradle/enhance/CubaEnhancer.java
+++ b/src/main/java/com/haulmont/gradle/enhance/CubaEnhancer.java
@@ -23,6 +23,7 @@ import javassist.bytecode.ConstPool;
 import javassist.bytecode.annotation.Annotation;
 import javassist.bytecode.annotation.MemberValue;
 import javassist.bytecode.annotation.StringMemberValue;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.logging.Logger;
 
@@ -135,7 +136,8 @@ public class CubaEnhancer {
                 throw new IllegalStateException(
                         String.format("Unable to enhance field %s.%s with primitive type %s. Use type %s.",
                                 ctClass.getName(), fieldName,
-                                setterParamType.getSimpleName(), StringUtils.capitalize(setterParamType.getSimpleName())));
+                                setterParamType.getSimpleName(),
+                                ((CtPrimitiveType) setterParamType).getWrapperName()));
             }
 
             ctMethod.addLocalVariable("__prev", setterParamType);


### PR DESCRIPTION
The CubeEnhancer would complain "Unable to enhance field <class>.<field> with primitive type int. Use type Int." This is incorrect, as primitive type int corresponds to Integer, not Int. Also, char corresponds to Character, not char.

The Javassist CtPrimitiveType does not have a method to return the simple name of the wrapper class.  The proposed change would make the message "Unable to enhance field <class>.<field> with primitive type int. Use type java.lang.Integer." Optionally, we could strip the package name with `.replaceAll("^.+\\.", "")`.