### PR TITLE
fix sort bug, use integer replaces string to sort

### DIFF
--- a/src/main/groovy/CubaDbScriptsAssembling.groovy
+++ b/src/main/groovy/CubaDbScriptsAssembling.groovy
@@ -67,10 +67,12 @@ class CubaDbScriptsAssembling extends DefaultTask {
             if (srcDbDir.exists() && dir.exists()) {
                 def moduleDirName = moduleAlias
                 if (!moduleDirName) {
-                    def moduleNames = Arrays.asList(dir.list()).sort()
+                    def moduleNames = Arrays.asList(dir.list()).sort { a, b ->
+                        a.substring(0, a.indexOf("-")).toInteger() - b.substring(0, b.indexOf("-")).toInteger()
+                    }
                     if (!moduleNames.empty) {
                         def lastName = moduleNames.last()
-                        def num = lastName.substring(0, 2).toInteger()
+                        def num = lastName.substring(0, lastName.indexOf("-")).toInteger()
                         moduleDirName = "${Math.max(50, num + 10)}-${project.rootProject.name}"
                     }
                 }


### PR DESCRIPTION
the string sort result in app-component db directory number-led doesn't increase number correctly when bigger than 100, for
```
10-cuba-xxx
50-abc-xxx
....
90-efg-xxx
100-xyz-xxx
```

sorted by string type will always get last module name 90-efg-xxx and generate repeated 100-xxx-xxx name